### PR TITLE
feat: update actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -55,7 +55,7 @@ jobs:
         version: 1.10.0
     - name: Build
       run: ninja -C ./v8/out.gn/arm64.release
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: v8_macos_arm64
         path: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,6 +39,9 @@ jobs:
         v8_enable_i18n_support = false
         v8_use_zlib = false
         use_custom_libcxx = false
+        mac_sdk_min = "14.0"
+        mac_min_system_version = "14.0"
+        mac_deployment_target = "14.0"
         v8_enable_i18n_support = false
         symbol_level = 0
         v8_enable_webassembly = false


### PR DESCRIPTION
`macOS-arm64` Job failed. 
- ```Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2``` [link](https://github.com/openwebf/v8/actions/runs/10878278000/job/30180903400)
  - Solution: Upgrade actions/upload-artifact to v3 
- `error: 'to_chars' is unavailable: introduced in macOS 13.3` [link](https://github.com/openwebf/v8/actions/runs/10878349663/job/30181096206)
  - Solution: Use the gn paramete ```mac_sdk_min = "14.0" mac_min_system_version = "14.0" mac_deployment_target = "14.0"```.  

[Successful Job](https://github.com/openwebf/v8/actions/runs/10878557443/job/30181651802)
